### PR TITLE
Feature [MSDEV-438] Generate domain code command

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,62 @@ Currently this installs the following dependencies
 
 Besides the dependencies this package also includes a `vendor/bin/dev` script
 which is a helper script to manage a project's docker compose setup
+
+# Domain Boilerplate Code Generation
+A few Artisan commands are available for automatic domain code generation. These can be used to setup a new domain more quickly. 
+
+| command                                             | description                                                                    |
+|-----------------------------------------------------|--------------------------------------------------------------------------------|
+| `make:domain {domain} {model}`                      | main entry to create entire domain                                             |
+| `make:domain-abstract-event {domain} {model}`       | generates common event super class                                             |
+| `make:domain-event {domain} {model} {type}`         | generate specific event (used by actions)                                      |
+| `make:domain-action {domain} {model} {type}`        | generate specific action                                                       |
+| `make:domain-dto {domain} {model} {type}`           | generate DTO to be used for either insterting or updating models in repository |
+| `make:domain-model {domain} {model}`                | generate the Eloquent model                                                    |
+| `make:domain-exception {domain} {model}`            | generate the generic exception                                                 |
+| `make:domain-repository-interface {domain} {model}` | generate the repository interface                                              |
+
+## Force option
+```
+  -f, --force           force generation when class already exists
+```
+All commands allow you to pass the `--force` option. using this option you can overwrite existing files in your domain. This might be required when upgrading current installments with newer definitions. By default this option is `false`, and commands will fail by saying that the file already exists.
+
+## `make:domain`
+This is the main entry point for generating everything. It takes a number of (optional) arguments:
+```
+  -a, --all             Generate all related files
+      --model           generate model
+      --repository      generate repository interface
+      --exception       generate exception
+      --actions         generate all actions
+      --create-action   generate create-action
+      --update-action   generate update-action
+      --delete-action   generate delete-action
+      --events          generate model
+      --abstract-event  generate abstract-event
+      --created-event   generate created-event
+      --updated-event   generate updated-event
+      --deleted-event   generate deleted-event
+      --dtos            generate all dtos
+      --create-dto      generate create-dto
+      --update-dto      generate update-dto
+```
+
+This means you can either pass `--all` to generate everything in 1 command, or specify what class you want to generate specifically by using one or more of the other options. 
+
+E.g. to generate only 2 specific actions and a repository for the `Bar` model in the `Foo` domain, run the following command:
+``` shell
+$ ./artisan make:domain Foo Bar --repository --create-action --delete-action
+```
+
+Please beware that all generated code has some expectations about other classes being available. e.g. the `Action`-classes all assume the existance of the `RepositoryInterface`, the `Model` and both the appropriate `Dto` and `Event` classes. This means you can run this command for a single class, but you might need to modify the code afterwards. 
+
+The actions, events and dtos created by `make:domain` are limited to `create(d)`,`udpate(d)` and `delete(d)`. You can create more types, but you'll have to call the `make:domain-* {domain} {model} {type}` manually. e.g.
+``` shell
+$ ./artisan make:domain-action Foo Bar update-email
+$ ./artisan make:domain-event Foo Bar update-email
+$ ./artisan make:domain-dto Foo Bar update-email
+```
+
+This will generate `Bar\UpdateEmailBarAction`, `Bar\BarUpdateEmailEvent`, and `Bar\UpdateEmailBarDto` classes. 

--- a/README.md
+++ b/README.md
@@ -45,8 +45,11 @@ This is the main entry point for generating everything. It takes a number of (op
       --delete-action   generate delete-action
       --events          generate model
       --abstract-event  generate abstract-event
+      --creating-event  generate creating-event
       --created-event   generate created-event
+      --updating-event  generate updating-event
       --updated-event   generate updated-event
+      --deleting-event  generate deleting-event
       --deleted-event   generate deleted-event
       --dtos            generate all dtos
       --create-dto      generate create-dto
@@ -70,3 +73,32 @@ $ ./artisan make:domain-dto Foo Bar update-email
 ```
 
 This will generate `Bar\UpdateEmailBarAction`, `Bar\BarUpdateEmailEvent`, and `Bar\UpdateEmailBarDto` classes. 
+
+Running the entire suite will result in the following generated files:
+```
+app/Domain/{domain}/
+  Actions/
+    {model}/
+      Create{model}Action
+      Delete{model}Action
+      Update{model}Action
+  Dtos/
+    {model}/
+      Create{model}Dto
+      Update{model}Dto
+  Events/
+    {model}/
+      Abstract{model}Event
+      {model}CreatingEvent
+      {model}CreatedEvent
+      {model}UpdatingEvent
+      {model}UpdatedEvent
+      {model}DeletingEvent
+      {model}DeletedEvent
+  Exceptions/
+    {model}Exception
+  Models/
+    {model}
+  Repositories/
+    {model}RepositoryInterface
+```

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ All commands allow you to pass the `--force` option. using this option you can o
 This is the main entry point for generating everything. It takes a number of (optional) arguments:
 ```
   -a, --all             Generate all related files
+      --namespace       The root namespace the domain should be part of. Default: Domain
       --model           generate model
       --repository      generate repository interface
       --exception       generate exception
@@ -102,3 +103,6 @@ app/Domain/{domain}/
   Repositories/
     {model}RepositoryInterface
 ```
+
+## Namespace option
+providing the `--namespace` option allows you to change the default `Domain` root namespace to something else. e.g. `--namespace "ThisIsDevelopment\\LaravelDomain"` will generate the following Product model in the Order domain: `ThisIsDevelopment\LaravelDomain\Order\Models\Product`. 

--- a/assets/stubs/domain-abstract-action.stub
+++ b/assets/stubs/domain-abstract-action.stub
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace {{ namespace }};
+
+use {{ repositoryInterfaceFqn }};
+
+abstract class {{ className }}
+{
+    public function __construct(
+        protected {{ repositoryInterface }} $repository
+    ) {
+    }
+}

--- a/assets/stubs/domain-abstract-event.stub
+++ b/assets/stubs/domain-abstract-event.stub
@@ -4,17 +4,9 @@ declare(strict_types=1);
 
 namespace {{ namespace }};
 
-use {{ fullModelClass }};
 use Illuminate\Queue\SerializesModels;
 
-abstract class Abstract{{ modelClass }}Event
+abstract class {{ className }}
 {
     use SerializesModels;
-
-    public {{ modelClass }} ${{ modelClassVariable }};
-
-    public function __construct({{ modelClass }} ${{ modelClassVariable }})
-    {
-        $this->{{ modelClassVariable }} = ${{ modelClassVariable }};
-    }
 }

--- a/assets/stubs/domain-abstract-event.stub
+++ b/assets/stubs/domain-abstract-event.stub
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace {{ namespace }};
+
+use {{ fullModelClass }};
+use Illuminate\Queue\SerializesModels;
+
+abstract class Abstract{{ modelClass }}Event
+{
+    use SerializesModels;
+
+    public {{ modelClass }} ${{ modelClassVariable }};
+
+    public function __construct({{ modelClass }} ${{ modelClassVariable }})
+    {
+        $this->{{ modelClassVariable }} = ${{ modelClassVariable }};
+    }
+}

--- a/assets/stubs/domain-create-action.stub
+++ b/assets/stubs/domain-create-action.stub
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace {{ namespace }};
+
+use {{ eventClass }};
+use {{ exceptionClass }};
+use {{ modelClass }};
+use {{ repositoryInterface }};
+
+class {{ class }}
+{
+    private {{ repositoryInterface }} $repository;
+
+    public function __construct({{ repositoryInterface }} $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    /**
+     * @throws {{ exceptionClass }}
+     */
+    public function execute({{ dtoClass }} $dto): {{ modelClass }}
+    {
+        ${{ modelClassVar } = $this->repository->create($dto);
+
+        event(new {{ eventClass }}(${{ modelClassVar }));
+
+        return ${{ modelClassVar };
+    }
+}

--- a/assets/stubs/domain-create-action.stub
+++ b/assets/stubs/domain-create-action.stub
@@ -5,24 +5,21 @@ declare(strict_types=1);
 namespace {{ namespace }};
 
 use {{ dtoFqn }};
-use {{ preEventFqn }};
-use {{ postEventFqn }};
 use {{ exceptionFqn }};
 use {{ modelFqn }};
-use {{ repositoryInterfaceFqn }};
+use {{ postEventFqn }};
+use {{ preEventFqn }};
 
-class {{ className }}
+class {{ className }} extends {{ parentClass }}
 {
-    public function __construct(private {{ repositoryInterface }} $repository)
-    {
-    }
-
     /**
      * @throws {{ exceptionClass }}
      */
-    public function execute({{ dtoClass }} $dto): {{ modelClass }}
+    public function execute({{ dtoClass }} $dto): {{ modelClass }}|bool
     {
-        event(new {{ preEventClass }}($dto));
+        if (!event(new {{ preEventClass }}($dto))) {
+            return false;
+        }
 
         $model = $this->repository->create($dto);
 

--- a/assets/stubs/domain-create-action.stub
+++ b/assets/stubs/domain-create-action.stub
@@ -4,18 +4,17 @@ declare(strict_types=1);
 
 namespace {{ namespace }};
 
-use {{ eventClass }};
-use {{ exceptionClass }};
-use {{ modelClass }};
-use {{ repositoryInterface }};
+use {{ dtoFqn }};
+use {{ preEventFqn }};
+use {{ postEventFqn }};
+use {{ exceptionFqn }};
+use {{ modelFqn }};
+use {{ repositoryInterfaceFqn }};
 
-class {{ class }}
+class {{ className }}
 {
-    private {{ repositoryInterface }} $repository;
-
-    public function __construct({{ repositoryInterface }} $repository)
+    public function __construct(private {{ repositoryInterface }} $repository)
     {
-        $this->repository = $repository;
     }
 
     /**
@@ -23,10 +22,12 @@ class {{ class }}
      */
     public function execute({{ dtoClass }} $dto): {{ modelClass }}
     {
-        ${{ modelClassVar } = $this->repository->create($dto);
+        event(new {{ preEventClass }}($dto));
 
-        event(new {{ eventClass }}(${{ modelClassVar }));
+        $model = $this->repository->create($dto);
 
-        return ${{ modelClassVar };
+        event(new {{ postEventClass }}($model, $dto));
+
+        return $model;
     }
 }

--- a/assets/stubs/domain-created-event.stub
+++ b/assets/stubs/domain-created-event.stub
@@ -12,5 +12,6 @@ class {{ className }} extends {{ extends }}
     public function __construct(
         public {{ modelClass }} ${{ modelVar }},
         public {{ dtoClass }} ${{ dtoVar }},
-    ) { }
+    ) {
+    }
 }

--- a/assets/stubs/domain-created-event.stub
+++ b/assets/stubs/domain-created-event.stub
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace {{ namespace }};
+
+use {{ modelFqn }};
+use {{ dtoFqn }};
+
+class {{ className }} extends {{ extends }}
+{
+    public function __construct(
+        public {{ modelClass }} ${{ modelVar }},
+        public {{ dtoClass }} ${{ dtoVar }},
+    ) { }
+}

--- a/assets/stubs/domain-creating-event.stub
+++ b/assets/stubs/domain-creating-event.stub
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace {{ namespace }};
+
+use {{ dtoFqn }};
+
+class {{ className }} extends {{ extends }}
+{
+    public function __construct(
+        public {{ dtoClass }} ${{ dtoVar }},
+    ) { }
+}

--- a/assets/stubs/domain-creating-event.stub
+++ b/assets/stubs/domain-creating-event.stub
@@ -10,5 +10,6 @@ class {{ className }} extends {{ extends }}
 {
     public function __construct(
         public {{ dtoClass }} ${{ dtoVar }},
-    ) { }
+    ) {
+    }
 }

--- a/assets/stubs/domain-delete-action.stub
+++ b/assets/stubs/domain-delete-action.stub
@@ -4,27 +4,29 @@ declare(strict_types=1);
 
 namespace {{ namespace }};
 
-use {{ eventClass }};
-use {{ exceptionClass }};
-use {{ modelClass }};
-use {{ repositoryInterface }};
+use {{ preEventFqn }};
+use {{ postEventFqn }};
+use {{ exceptionFqn }};
+use {{ modelFqn }};
+use {{ repositoryInterfaceFqn }};
 
-class {{ class }}
+class {{ className }}
 {
-    private {{ repositoryInterface }} $repository;
-
-    public function __construct({{ repositoryInterface }} $repository)
+    public function __construct(private {{ repositoryInterface }} $repository)
     {
-        $this->repository = $repository;
     }
 
     /**
      * @throws {{ exceptionClass }}
      */
-    public function execute({{ modelClass }} ${{ modelClassVar }})
+    public function execute({{ modelClass }} $model)
     {
-        $this->repository->delete(${{ modelClassVar }});
+        event(new {{ preEventClass }}($model));
 
-        event(new {{ eventClass }}(${{ modelClassVar }));
+        $modelId = $model->id;
+
+        $this->repository->delete($model);
+
+        event(new {{ postEventClass }}($modelId));
     }
 }

--- a/assets/stubs/domain-delete-action.stub
+++ b/assets/stubs/domain-delete-action.stub
@@ -4,29 +4,28 @@ declare(strict_types=1);
 
 namespace {{ namespace }};
 
-use {{ preEventFqn }};
-use {{ postEventFqn }};
 use {{ exceptionFqn }};
 use {{ modelFqn }};
-use {{ repositoryInterfaceFqn }};
+use {{ postEventFqn }};
+use {{ preEventFqn }};
 
-class {{ className }}
+class {{ className }} extends {{ parentClass }}
 {
-    public function __construct(private {{ repositoryInterface }} $repository)
-    {
-    }
-
     /**
      * @throws {{ exceptionClass }}
      */
-    public function execute({{ modelClass }} $model)
+    public function execute({{ modelClass }} $model): bool
     {
-        event(new {{ preEventClass }}($model));
+        if (!event(new {{ preEventClass }}($model))) {
+            return false;
+        }
 
         $modelId = $model->id;
 
         $this->repository->delete($model);
 
         event(new {{ postEventClass }}($modelId));
+
+        return true;
     }
 }

--- a/assets/stubs/domain-delete-action.stub
+++ b/assets/stubs/domain-delete-action.stub
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace {{ namespace }};
+
+use {{ eventClass }};
+use {{ exceptionClass }};
+use {{ modelClass }};
+use {{ repositoryInterface }};
+
+class {{ class }}
+{
+    private {{ repositoryInterface }} $repository;
+
+    public function __construct({{ repositoryInterface }} $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    /**
+     * @throws {{ exceptionClass }}
+     */
+    public function execute({{ modelClass }} ${{ modelClassVar }})
+    {
+        $this->repository->delete(${{ modelClassVar }});
+
+        event(new {{ eventClass }}(${{ modelClassVar }));
+    }
+}

--- a/assets/stubs/domain-deleted-event.stub
+++ b/assets/stubs/domain-deleted-event.stub
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace {{ namespace }};
+
+class {{ className }} extends {{ extends }}
+{
+    public function __construct(
+        public int $id
+    ) { }
+}

--- a/assets/stubs/domain-deleted-event.stub
+++ b/assets/stubs/domain-deleted-event.stub
@@ -8,5 +8,6 @@ class {{ className }} extends {{ extends }}
 {
     public function __construct(
         public int $id
-    ) { }
+    ) {
+    }
 }

--- a/assets/stubs/domain-deleting-event.stub
+++ b/assets/stubs/domain-deleting-event.stub
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace {{ namespace }};
+
+use {{ modelFqn }};
+
+class {{ className }} extends {{ extends }}
+{
+    public function __construct(
+        public {{ modelClass }} ${{ modelVar }},
+    ) { }
+}

--- a/assets/stubs/domain-deleting-event.stub
+++ b/assets/stubs/domain-deleting-event.stub
@@ -10,5 +10,6 @@ class {{ className }} extends {{ extends }}
 {
     public function __construct(
         public {{ modelClass }} ${{ modelVar }},
-    ) { }
+    ) {
+    }
 }

--- a/assets/stubs/domain-dto.stub
+++ b/assets/stubs/domain-dto.stub
@@ -1,0 +1,10 @@
+<?php
+
+namespace {{ namespace }};
+
+use Spatie\DataTransferObject\DataTransferObject;
+
+class {{ class }} extends DataTransferObject
+{
+    {{ properties }}
+}

--- a/assets/stubs/domain-dto.stub
+++ b/assets/stubs/domain-dto.stub
@@ -4,7 +4,7 @@ namespace {{ namespace }};
 
 use Spatie\DataTransferObject\DataTransferObject;
 
-class {{ class }} extends DataTransferObject
+class {{ className }} extends DataTransferObject
 {
-    {{ properties }}
+    /* @todo  Add properties */
 }

--- a/assets/stubs/domain-event.stub
+++ b/assets/stubs/domain-event.stub
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace {{ namespace }};
+
+class {{ modelClass }}{{ event }}Event extends Abstract{{ modelClass }}Event
+{
+}

--- a/assets/stubs/domain-event.stub
+++ b/assets/stubs/domain-event.stub
@@ -1,9 +1,0 @@
-<?php
-
-declare(strict_types=1);
-
-namespace {{ namespace }};
-
-class {{ modelClass }}{{ event }}Event extends Abstract{{ modelClass }}Event
-{
-}

--- a/assets/stubs/domain-exception.stub
+++ b/assets/stubs/domain-exception.stub
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace {{ namespace }};
+
+use Exception;
+
+class {{ class }} extends Exception
+{
+    //
+}

--- a/assets/stubs/domain-exception.stub
+++ b/assets/stubs/domain-exception.stub
@@ -6,7 +6,7 @@ namespace {{ namespace }};
 
 use Exception;
 
-class {{ class }} extends Exception
+class {{ className }} extends Exception
 {
     //
 }

--- a/assets/stubs/domain-model.stub
+++ b/assets/stubs/domain-model.stub
@@ -1,0 +1,11 @@
+<?php
+
+namespace {{ namespace }};
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class {{ class }} extends Model
+{
+    use HasFactory;
+}

--- a/assets/stubs/domain-model.stub
+++ b/assets/stubs/domain-model.stub
@@ -5,7 +5,7 @@ namespace {{ namespace }};
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
-class {{ class }} extends Model
+class {{ className }} extends Model
 {
     use HasFactory;
 }

--- a/assets/stubs/domain-repository-interface.stub
+++ b/assets/stubs/domain-repository-interface.stub
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace {{ namespace }};
+
+use {{ exceptionClass }};
+use {{ modelClass }};
+use {{ dtoClass }};
+
+interface {{ class }}
+{
+    /**
+     * @throws {{ exceptionClass }}
+     */
+    public function create({{ dtoClass }} $dto): Redirect;
+
+    /**
+     * @throws {{ exceptionClass }}
+     */
+    public function update({{ modelClass }} ${{ modelClassVar }}, {{ dtoClass }} $dto): {{ modelClass }};
+
+    /**
+     * @throws {{ exceptionClass }}
+     */
+    public function delete({{ modelClass }} ${{ modelClassVar }}): void;
+}

--- a/assets/stubs/domain-repository-interface.stub
+++ b/assets/stubs/domain-repository-interface.stub
@@ -4,24 +4,25 @@ declare(strict_types=1);
 
 namespace {{ namespace }};
 
-use {{ exceptionClass }};
-use {{ modelClass }};
-use {{ dtoClass }};
+use {{ exceptionFqn }};
+use {{ modelFqn }};
+use {{ createDtoFqn }};
+use {{ updateDtoFqn }};
 
-interface {{ class }}
+interface {{ className }}
 {
     /**
      * @throws {{ exceptionClass }}
      */
-    public function create({{ dtoClass }} $dto): Redirect;
+    public function create({{ createDtoClass }} $dto): {{ modelClass }};
 
     /**
      * @throws {{ exceptionClass }}
      */
-    public function update({{ modelClass }} ${{ modelClassVar }}, {{ dtoClass }} $dto): {{ modelClass }};
+    public function update({{ modelClass }} $model, {{ updateDtoClass }} $dto): {{ modelClass }};
 
     /**
      * @throws {{ exceptionClass }}
      */
-    public function delete({{ modelClass }} ${{ modelClassVar }}): void;
+    public function delete({{ modelClass }} $model): void;
 }

--- a/assets/stubs/domain-update-action.stub
+++ b/assets/stubs/domain-update-action.stub
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace {{ namespace }};
+
+use {{ eventClass }};
+use {{ exceptionClass }};
+use {{ modelClass }};
+use {{ repositoryInterface }};
+
+class {{ class }}
+{
+    private {{ repositoryInterface }} $repository;
+
+    public function __construct({{ repositoryInterface }} $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    /**
+     * @throws {{ exceptionClass }}
+     */
+    public function execute({{ modelClass }} ${{ modelClassVar }}, {{ dtoClass }} $dto): {{ modelClass }}
+    {
+        ${{ modelClassVar } = $this->repository->update(${{ modelClassVar }}, $dto);
+
+        event(new {{ eventClass }}(${{ modelClassVar }));
+
+        return ${{ modelClassVar };
+    }
+}

--- a/assets/stubs/domain-update-action.stub
+++ b/assets/stubs/domain-update-action.stub
@@ -4,25 +4,22 @@ declare(strict_types=1);
 
 namespace {{ namespace }};
 
-use {{ preEventFqn }};
-use {{ postEventFqn }};
+use {{ dtoFqn }};
 use {{ exceptionFqn }};
 use {{ modelFqn }};
-use {{ repositoryInterfaceFqn }};
-use {{ dtoFqn }};
+use {{ postEventFqn }};
+use {{ preEventFqn }};
 
-class {{ className }}
+class {{ className }} extends {{ parentClass }}
 {
-    public function __construct(private {{ repositoryInterface }} $repository)
-    {
-    }
-
     /**
      * @throws {{ exceptionClass }}
      */
-    public function execute({{ modelClass }} $model, {{ dtoClass }} $dto): {{ modelClass }}
+    public function execute({{ modelClass }} $model, {{ dtoClass }} $dto): {{ modelClass }}|bool
     {
-        event(new {{ preEventClass }}($model, $dto));
+        if (!event(new {{ preEventClass }}($model, $dto))) {
+            return false;
+        }
 
         $model = $this->repository->{{ repositoryAction }}($model, $dto);
 
@@ -30,4 +27,4 @@ class {{ className }}
 
         return $model;
     }
-}y
+}

--- a/assets/stubs/domain-update-action.stub
+++ b/assets/stubs/domain-update-action.stub
@@ -4,29 +4,30 @@ declare(strict_types=1);
 
 namespace {{ namespace }};
 
-use {{ eventClass }};
-use {{ exceptionClass }};
-use {{ modelClass }};
-use {{ repositoryInterface }};
+use {{ preEventFqn }};
+use {{ postEventFqn }};
+use {{ exceptionFqn }};
+use {{ modelFqn }};
+use {{ repositoryInterfaceFqn }};
+use {{ dtoFqn }};
 
-class {{ class }}
+class {{ className }}
 {
-    private {{ repositoryInterface }} $repository;
-
-    public function __construct({{ repositoryInterface }} $repository)
+    public function __construct(private {{ repositoryInterface }} $repository)
     {
-        $this->repository = $repository;
     }
 
     /**
      * @throws {{ exceptionClass }}
      */
-    public function execute({{ modelClass }} ${{ modelClassVar }}, {{ dtoClass }} $dto): {{ modelClass }}
+    public function execute({{ modelClass }} $model, {{ dtoClass }} $dto): {{ modelClass }}
     {
-        ${{ modelClassVar } = $this->repository->update(${{ modelClassVar }}, $dto);
+        event(new {{ preEventClass }}($model, $dto));
 
-        event(new {{ eventClass }}(${{ modelClassVar }));
+        $model = $this->repository->{{ repositoryAction }}($model, $dto);
 
-        return ${{ modelClassVar };
+        event(new {{ postEventClass }}($model, $dto));
+
+        return $model;
     }
-}
+}y

--- a/assets/stubs/domain-update-event.stub
+++ b/assets/stubs/domain-update-event.stub
@@ -12,5 +12,6 @@ class {{ className }} extends {{ extends }}
     public function __construct(
         public {{ modelClass }} ${{ modelVar }},
         public {{ dtoClass }} ${{ dtoVar }},
-    ) { }
+    ) {
+    }
 }

--- a/assets/stubs/domain-update-event.stub
+++ b/assets/stubs/domain-update-event.stub
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace {{ namespace }};
+
+use {{ modelFqn }};
+use {{ dtoFqn }};
+
+class {{ className }} extends {{ extends }}
+{
+    public function __construct(
+        public {{ modelClass }} ${{ modelVar }},
+        public {{ dtoClass }} ${{ dtoVar }},
+    ) { }
+}

--- a/composer.json
+++ b/composer.json
@@ -40,5 +40,5 @@
             "ThisIsDevelopment\\LaravelBaseDev\\": "src/"
         }
     },
-    "version": "0.5.4"
+    "version": "0.5.5"
 }

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": ">=7.2",
+        "php": ">=8.0",
         "squizlabs/php_codesniffer": "^3.5",
         "barryvdh/laravel-debugbar": "^3.2",
         "barryvdh/laravel-ide-helper": "^2.6",

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
         "barryvdh/laravel-ide-helper": "^2.6",
         "thisisdevelopment/laravel-test-snapshot": "^0.3.0",
         "vlucas/phpdotenv": "^4.0|^5.0",
-        "illuminate/console": "6.x | 7.x | 8.x",
-        "illuminate/support": "6.x | 7.x | 8.x"
+        "illuminate/console": "6.x | 7.x | 8.x | 9.x",
+        "illuminate/support": "6.x | 7.x | 8.x | 9.x"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,9 @@
         "barryvdh/laravel-debugbar": "^3.2",
         "barryvdh/laravel-ide-helper": "^2.6",
         "thisisdevelopment/laravel-test-snapshot": "^0.3.0",
-        "vlucas/phpdotenv": "^4.0|^5.0"
+        "vlucas/phpdotenv": "^4.0|^5.0",
+        "illuminate/console": "6.x | 7.x | 8.x",
+        "illuminate/support": "6.x | 7.x | 8.x"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,
@@ -25,5 +27,18 @@
         "assets/bin/dev",
         "assets/bin/wait-db",
         "assets/bin/wait-redis"
-    ]
+    ],
+    "extra": {
+        "laravel": {
+            "providers": [
+                "ThisIsDevelopment\\LaravelBaseDev\\Providers\\BaseDevServiceProvider"
+            ]
+        }
+    },
+    "autoload": {
+        "psr-4": {
+            "ThisIsDevelopment\\LaravelBaseDev\\": "src/"
+        }
+    },
+    "version": "0.5.4"
 }

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,10 @@
         {
             "name": "Eric de Ruiter",
             "email": "eric@thisisdevelopment.nl"
+        },
+        {
+            "name": "Jeroen Faijdherbe",
+            "email": "jeroen@thisisdevelopment.nl"
         }
     ],
     "require": {
@@ -39,6 +43,5 @@
         "psr-4": {
             "ThisIsDevelopment\\LaravelBaseDev\\": "src/"
         }
-    },
-    "version": "0.5.5"
+    }
 }

--- a/src/Commands/AbstractDomainGeneratorCommand.php
+++ b/src/Commands/AbstractDomainGeneratorCommand.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace ThisIsDevelopment\LaravelBaseDev\Commands;
+
+use Illuminate\Console\GeneratorCommand;
+use Illuminate\Support\Str;
+use Symfony\Component\Console\Input\InputArgument;
+
+abstract class AbstractDomainGeneratorCommand extends GeneratorCommand
+{
+    protected $hasMultiplePerModel = true;
+
+    public function rootNamespace(): string
+    {
+        return '\\Domain';
+    }
+
+    protected function getStub(): string
+    {
+        return $this->resolveStubPath(sprintf("/stubs/%s.stub", Str::slug(class_basename($this))));
+    }
+
+    protected function resolveStubPath($stub): string
+    {
+        return file_exists($customPath = $this->laravel->basePath(trim($stub, '/')))
+            ? $customPath
+            : __DIR__.'/../../assets' . $stub;
+    }
+
+    protected function getArguments(): array
+    {
+        return array_filter([
+            ['domain', InputArgument::REQUIRED, 'The name of the domain'],
+            $this->type === 'Model' ? null : ['model', InputArgument::REQUIRED, 'The name of the model'],
+            ['name', InputArgument::REQUIRED, 'The name of the ' . $this->type],
+        ]);
+    }
+
+    protected function getNameInput(): string
+    {
+        return trim($this->argument('name'));
+    }
+
+    protected function getDefaultNamespace($rootNamespace): string
+    {
+        return sprintf(
+            "%s\\%s%s",
+            $rootNamespace,
+            Str::plural($this->type),
+            $this->hasMultiplePerModel ? '\\' . $this->input->getArgument('model') : ''
+        );
+    }
+}

--- a/src/Commands/AbstractDomainGeneratorCommand.php
+++ b/src/Commands/AbstractDomainGeneratorCommand.php
@@ -10,14 +10,7 @@ use ThisIsDevelopment\LaravelBaseDev\Helpers\FqnHelper;
 
 abstract class AbstractDomainGeneratorCommand extends GeneratorCommand
 {
-    public const ROOT_NAMESPACE_DEFAULT = 'ThisIsDevelopment\Domain';
-
-    /**
-     * Root namespace of the class to be generated.
-     *
-     * @var string
-     **/
-    protected string $rootNamespace = self::ROOT_NAMESPACE_DEFAULT;
+    public const ROOT_NAMESPACE_DEFAULT = 'Domain';
 
     /**
      * Optional stub path override
@@ -46,7 +39,10 @@ abstract class AbstractDomainGeneratorCommand extends GeneratorCommand
 
     public function rootNamespace(): string
     {
-        return $this->rootNamespace;
+        return trim(
+            str_replace('/', '\\', $this->option('namespace')),
+            '\\'
+        );
     }
 
     /** Stub related **/
@@ -109,7 +105,8 @@ abstract class AbstractDomainGeneratorCommand extends GeneratorCommand
     protected function getOptions(): array
     {
         return [
-            ['force', null, InputOption::VALUE_NONE, 'force generation when class already exists']
+            ['force', null, InputOption::VALUE_NONE, 'force generation when class already exists'],
+            ['namespace', null, InputOption::VALUE_OPTIONAL, 'The domain workspace.', self::ROOT_NAMESPACE_DEFAULT],
         ];
     }
 

--- a/src/Commands/AbstractDomainGeneratorCommand.php
+++ b/src/Commands/AbstractDomainGeneratorCommand.php
@@ -5,49 +5,170 @@ namespace ThisIsDevelopment\LaravelBaseDev\Commands;
 use Illuminate\Console\GeneratorCommand;
 use Illuminate\Support\Str;
 use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+use ThisIsDevelopment\LaravelBaseDev\Generators\FqnHelper;
 
 abstract class AbstractDomainGeneratorCommand extends GeneratorCommand
 {
-    protected $hasMultiplePerModel = true;
+    public const ROOT_NAMESPACE_DEFAULT = 'ThisIsDevelopment\Domain';
+
+    /**
+     * Root namespace of the class to be generated.
+     *
+     * @var string
+     **/
+    protected string $rootNamespace = self::ROOT_NAMESPACE_DEFAULT;
+
+    /**
+     * Optional stub path override
+     *
+     * @var string
+     **/
+    protected ?string $stub = null;
+
+    /**
+     * FQN Helper class for easy fqn/classname generation based on
+     * current domain/model
+     *
+     * @var FqnHelper
+     **/
+    private FqnHelper $fqnHelper;
+
+    public function handle(): bool|null
+    {
+        // if type is not set, automatically set it to the full class
+        // FQN for more descriptive console output
+        $this->type = $this->type ?: $this->getClassFqn();
+
+        // let parent handle actual command
+        return parent::handle();
+    }
 
     public function rootNamespace(): string
     {
-        return '\\Domain';
+        return $this->rootNamespace;
     }
 
+    /** Stub related **/
     protected function getStub(): string
     {
-        return $this->resolveStubPath(sprintf("/stubs/%s.stub", Str::slug(class_basename($this))));
+        return $this->resolveStubPath(
+            $this->getStubName()
+        );
+    }
+
+    protected function getStubName(): string
+    {
+        return $this->stub ?: $this->generateStubName();
+    }
+
+    protected function generateStubName(): string
+    {
+        return "stubs/" . Str::kebab(
+            str_replace('Make', '', class_basename($this))
+        ) . '.stub';
     }
 
     protected function resolveStubPath($stub): string
     {
         return file_exists($customPath = $this->laravel->basePath(trim($stub, '/')))
             ? $customPath
-            : __DIR__.'/../../assets' . $stub;
+            : __DIR__ . '/../../assets/' . ltrim($stub, '/');
+    }
+
+    protected function getPath($name)
+    {
+        return implode('/', [
+            $this->laravel->basePath('app'),
+            'Domain',
+            ...explode('\\', trim(str_replace($this->rootNamespace(), '', $name), '\\'))
+        ]) . '.php';
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * The desired classname will be determined by the
+     * getClassFqn() method instead of by a command argument
+     **/
+    protected function getNameInput(): string
+    {
+        return $this->getClassFqn();
+    }
+
+    protected function fqnHelper(): FqnHelper
+    {
+        return $this->fqnHelper
+            ?? $this->fqnHelper = new FqnHelper(
+                $this->rootNamespace(),
+                $this->argument('domain'),
+                $this->argument('model')
+            );
+    }
+
+    protected function getOptions(): array
+    {
+        return [
+            ['force', null, InputOption::VALUE_NONE, 'force generation when class already exists']
+        ];
     }
 
     protected function getArguments(): array
     {
         return array_filter([
             ['domain', InputArgument::REQUIRED, 'The name of the domain'],
-            $this->type === 'Model' ? null : ['model', InputArgument::REQUIRED, 'The name of the model'],
-            ['name', InputArgument::REQUIRED, 'The name of the ' . $this->type],
+            ['model', InputArgument::REQUIRED, 'The name of the model'],
         ]);
     }
 
-    protected function getNameInput(): string
+    protected function buildClass($name)
     {
-        return trim($this->argument('name'));
+        $file = $this->files->get($this->getStub());
+
+        foreach ($this->getVariables() as $key => $value) {
+            // `str_replace`...? Yeah i know, but this is how laravel
+            // also does it themselves and i did not want to deviate
+            // to much...  a nice improvement might be using Blade or
+            // Mustache instead, which will also greatly improve
+            // flexibility
+            $file = str_replace($this->convertKey($key), $value, $file);
+        }
+
+        return $file;
     }
 
-    protected function getDefaultNamespace($rootNamespace): string
+    /**
+     * Allow a variaty of key naming by generating a list of possible
+     * writing options for given key.
+     *
+     * The keys generated are based slightly on the names used by laravels own generator
+     *
+     * @return string[]
+     **/
+    private function convertKey($key): array
     {
-        return sprintf(
-            "%s\\%s%s",
-            $rootNamespace,
-            Str::plural($this->type),
-            $this->hasMultiplePerModel ? '\\' . $this->input->getArgument('model') : ''
-        );
+        return [
+            sprintf('{{ %s }}', $key),
+            sprintf('{{ %s}}', $key),
+            sprintf('{{%s }}', $key),
+            sprintf('{{%s}}', $key),
+            Str::studly("dummy_{$key}"),
+        ];
+    }
+
+    /**
+     * The FQN of the class to be generated.
+     *
+     * @return string
+     **/
+    abstract protected function getClassFqn(): string;
+
+    /**
+     * provide list of variables to replace in stubs in the form of an associative array.
+     *
+     **/
+    protected function getVariables(): array
+    {
+        return [];
     }
 }

--- a/src/Commands/AbstractDomainGeneratorCommand.php
+++ b/src/Commands/AbstractDomainGeneratorCommand.php
@@ -6,7 +6,7 @@ use Illuminate\Console\GeneratorCommand;
 use Illuminate\Support\Str;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
-use ThisIsDevelopment\LaravelBaseDev\Generators\FqnHelper;
+use ThisIsDevelopment\LaravelBaseDev\Helpers\FqnHelper;
 
 abstract class AbstractDomainGeneratorCommand extends GeneratorCommand
 {

--- a/src/Commands/MakeDomain.php
+++ b/src/Commands/MakeDomain.php
@@ -87,6 +87,7 @@ class MakeDomain extends Command
         return [
             ['force', 'f', InputOption::VALUE_NONE, 'force generation when class already exists'],
             ['all', 'a', InputOption::VALUE_NONE, 'Generate all related files'],
+            ['namespace', null, InputOption::VALUE_OPTIONAL, AbstractDomainGeneratorCommand::ROOT_NAMESPACE_DEFAULT],
 
             ['model', null, InputOption::VALUE_NONE, 'Generate model'],
             ['repository', null, InputOption::VALUE_NONE, 'Generate repository interface'],
@@ -127,6 +128,7 @@ class MakeDomain extends Command
             'domain' => $this->argument('domain'),
             'model' => $this->argument('model'),
             '--force' => $this->option('force'),
+            '--namespace' => $this->option('namespace'),
         ]);
     }
 
@@ -136,6 +138,7 @@ class MakeDomain extends Command
             'domain' => $this->argument('domain'),
             'model' => $this->argument('model'),
             '--force' => $this->option('force'),
+            '--namespace' => $this->option('namespace'),
         ]);
     }
 
@@ -146,6 +149,7 @@ class MakeDomain extends Command
             'model' => $this->argument('model'),
             'type' => $type,
             '--force' => $this->option('force'),
+            '--namespace' => $this->option('namespace'),
         ]);
     }
 
@@ -155,28 +159,29 @@ class MakeDomain extends Command
             'domain' => $this->argument('domain'),
             'model' => $this->argument('model'),
             '--force' => $this->option('force'),
+            '--namespace' => $this->option('namespace'),
         ]);
     }
 
     private function createAbstractAction(): int
     {
-        return
-            $this->call(MakeDomainAbstractAction::class, [
-                'domain' => $this->argument('domain'),
-                'model' => $this->argument('model'),
-                '--force' => $this->option('force'),
-            ]);
+        return $this->call(MakeDomainAbstractAction::class, [
+            'domain' => $this->argument('domain'),
+            'model' => $this->argument('model'),
+            '--force' => $this->option('force'),
+            '--namespace' => $this->option('namespace'),
+        ]);
     }
 
     private function createAction(string $type): int
     {
-        return
-            $this->call(MakeDomainAction::class, [
-                'domain' => $this->argument('domain'),
-                'model' => $this->argument('model'),
-                'type' => $type,
-                '--force' => $this->option('force'),
-            ]);
+        return $this->call(MakeDomainAction::class, [
+            'domain' => $this->argument('domain'),
+            'model' => $this->argument('model'),
+            'type' => $type,
+            '--force' => $this->option('force'),
+            '--namespace' => $this->option('namespace'),
+        ]);
     }
 
     private function createAbstractEvent(): int
@@ -185,6 +190,7 @@ class MakeDomain extends Command
             'domain' => $this->argument('domain'),
             'model' => $this->argument('model'),
             '--force' => $this->option('force'),
+            '--namespace' => $this->option('namespace'),
         ]);
     }
 
@@ -195,6 +201,7 @@ class MakeDomain extends Command
             'model' => $this->argument('model'),
             'type' => $event,
             '--force' => $this->option('force'),
+            '--namespace' => $this->option('namespace'),
         ]);
     }
 }

--- a/src/Commands/MakeDomain.php
+++ b/src/Commands/MakeDomain.php
@@ -1,0 +1,186 @@
+<?php
+
+namespace ThisIsDevelopment\LaravelBaseDev\Commands;
+
+use Illuminate\Console\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+
+class MakeDomain extends Command
+{
+    protected $name = 'make:domain';
+
+    protected $description = 'Create a new domain-model class';
+
+    public function handle()
+    {
+        // model
+        if ($this->wantsOneOf(['all', 'model'])) {
+            $this->createModel();
+        }
+
+        // exception
+        if ($this->wantsOneOf(['all', 'exception'])) {
+            $this->createException();
+        }
+
+        // dtos
+        if ($this->wantsOneOf(['all', 'dtos', 'create-dto'])) {
+            $this->createDto('create');
+        }
+        if ($this->wantsOneOf(['all', 'dtos', 'update-dto'])) {
+            $this->createDto('update');
+        }
+
+        // repository interface
+        if ($this->wantsOneOf(['all', 'repository'])) {
+            $this->createRepositoryInterface();
+        }
+
+        // actions
+        if ($this->wantsOneOf(['all', 'actions', 'create-action'])) {
+            $this->createAction('create');
+        }
+        if ($this->wantsOneOf(['all', 'actions', 'update-action'])) {
+            $this->createAction('update');
+        }
+        if ($this->wantsOneOf(['all', 'actions', 'delete-action'])) {
+            $this->createAction('delete');
+        }
+
+        // events
+        if ($this->wantsOneOf(['all', 'events', 'abstract-event'])) {
+            $this->createAbstractEvent();
+        }
+        if ($this->wantsOneOf(['all', 'events', 'creating-event'])) {
+            $this->createEvent('creating');
+        }
+        if ($this->wantsOneOf(['all', 'events', 'created-event'])) {
+            $this->createEvent('created');
+        }
+        if ($this->wantsOneOf(['all', 'events', 'updating-event'])) {
+            $this->createEvent('updating');
+        }
+        if ($this->wantsOneOf(['all', 'events', 'updated-event'])) {
+            $this->createEvent('updated');
+        }
+        if ($this->wantsOneOf(['all', 'events', 'deleting-event'])) {
+            $this->createEvent('deleting');
+        }
+        if ($this->wantsOneOf(['all', 'events', 'deleted-event'])) {
+            $this->createEvent('deleted');
+        }
+
+        return null;
+    }
+
+    private function wantsOneOf(array|string $options): bool
+    {
+        return in_array(true, array_filter((array)$options, fn ($opt) => $this->option($opt)));
+    }
+
+    protected function getOptions(): array
+    {
+        return [
+            ['force', 'f', InputOption::VALUE_NONE, 'force generation when class already exists'],
+            ['all', 'a', InputOption::VALUE_NONE, 'Generate all related files'],
+
+            ['model', null, InputOption::VALUE_NONE, 'Generate model'],
+            ['repository', null, InputOption::VALUE_NONE, 'Generate repository interface'],
+            ['exception', null, InputOption::VALUE_NONE, 'Generate exception'],
+
+            ['actions', null, InputOption::VALUE_NONE, 'Generate all actions'],
+            ['create-action', null, InputOption::VALUE_NONE, 'Generate create-action'],
+            ['update-action', null, InputOption::VALUE_NONE, 'Generate update-action'],
+            ['delete-action', null, InputOption::VALUE_NONE, 'Generate delete-action'],
+
+            ['events', null, InputOption::VALUE_NONE, 'Generate all common events'],
+            ['abstract-event', null, InputOption::VALUE_NONE, 'Generate abstract-event'],
+            ['creating-event', null, InputOption::VALUE_NONE, 'Generate creating-event'],
+            ['created-event', null, InputOption::VALUE_NONE, 'Generate created-event'],
+            ['updating-event', null, InputOption::VALUE_NONE, 'Generate updating-event'],
+            ['updated-event', null, InputOption::VALUE_NONE, 'Generate updated-event'],
+            ['deleting-event', null, InputOption::VALUE_NONE, 'Generate deleting-event'],
+            ['deleted-event', null, InputOption::VALUE_NONE, 'Generate deleted-event'],
+
+            ['dtos', null, InputOption::VALUE_NONE, 'Generate all dtos'],
+            ['create-dto', null, InputOption::VALUE_NONE, 'Generate create-dto'],
+            ['update-dto', null, InputOption::VALUE_NONE, 'Generate update-dto'],
+        ];
+    }
+
+    protected function getArguments(): array
+    {
+        return array_filter([
+            ['domain', InputArgument::REQUIRED, 'The name of the domain'],
+            ['model', InputArgument::REQUIRED, 'The name of the model'],
+        ]);
+    }
+
+    private function createModel(): int
+    {
+        return $this->call(MakeDomainModel::class, [
+            'domain' => $this->argument('domain'),
+            'model' => $this->argument('model'),
+            '--force' => $this->option('force'),
+        ]);
+    }
+
+    private function createException(): int
+    {
+        return $this->call(MakeDomainException::class, [
+            'domain' => $this->argument('domain'),
+            'model' => $this->argument('model'),
+            '--force' => $this->option('force'),
+        ]);
+    }
+
+    private function createDto(string $type): int
+    {
+        return $this->call(MakeDomainDto::class, [
+            'domain' => $this->argument('domain'),
+            'model' => $this->argument('model'),
+            'type' => $type,
+            '--force' => $this->option('force'),
+        ]);
+    }
+
+    private function createRepositoryInterface(): int
+    {
+        return $this->call(MakeDomainRepositoryInterface::class, [
+            'domain' => $this->argument('domain'),
+            'model' => $this->argument('model'),
+            '--force' => $this->option('force'),
+        ]);
+    }
+
+    private function createAction(string $type): int
+    {
+        return
+            $this->call(MakeDomainAction::class, [
+                'domain' => $this->argument('domain'),
+                'model' => $this->argument('model'),
+                'type' => $type,
+                '--force' => $this->option('force'),
+            ]);
+    }
+
+    private function createAbstractEvent(): int
+    {
+        return $this->call(MakeDomainAbstractEvent::class, [
+            'domain' => $this->argument('domain'),
+            'model' => $this->argument('model'),
+            '--force' => $this->option('force'),
+        ]);
+    }
+
+    private function createEvent(string $event): int
+    {
+        return $this->call(MakeDomainEvent::class, [
+            'domain' => $this->argument('domain'),
+            'model' => $this->argument('model'),
+            'type' => $event,
+            '--force' => $this->option('force'),
+        ]);
+    }
+}

--- a/src/Commands/MakeDomain.php
+++ b/src/Commands/MakeDomain.php
@@ -38,6 +38,9 @@ class MakeDomain extends Command
         }
 
         // actions
+        if ($this->wantsOneOf(['all', 'actions', 'abstract-action'])) {
+            $this->createAbstractAction();
+        }
         if ($this->wantsOneOf(['all', 'actions', 'create-action'])) {
             $this->createAction('create');
         }
@@ -90,6 +93,7 @@ class MakeDomain extends Command
             ['exception', null, InputOption::VALUE_NONE, 'Generate exception'],
 
             ['actions', null, InputOption::VALUE_NONE, 'Generate all actions'],
+            ['abstract-action', null, InputOption::VALUE_NONE, 'Generate abstract-action'],
             ['create-action', null, InputOption::VALUE_NONE, 'Generate create-action'],
             ['update-action', null, InputOption::VALUE_NONE, 'Generate update-action'],
             ['delete-action', null, InputOption::VALUE_NONE, 'Generate delete-action'],
@@ -152,6 +156,16 @@ class MakeDomain extends Command
             'model' => $this->argument('model'),
             '--force' => $this->option('force'),
         ]);
+    }
+
+    private function createAbstractAction(): int
+    {
+        return
+            $this->call(MakeDomainAbstractAction::class, [
+                'domain' => $this->argument('domain'),
+                'model' => $this->argument('model'),
+                '--force' => $this->option('force'),
+            ]);
     }
 
     private function createAction(string $type): int

--- a/src/Commands/MakeDomainAbstractAction.php
+++ b/src/Commands/MakeDomainAbstractAction.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace ThisIsDevelopment\LaravelBaseDev\Commands;
+
+use Illuminate\Support\Str;
+
+class MakeDomainAbstractAction extends AbstractDomainGeneratorCommand
+{
+    protected $name = 'make:domain-abstract-action';
+
+    protected $description = 'Create a new abstract gdomain-action class';
+
+    protected function getClassFqn(): string
+    {
+        return $this->fqnHelper()->fqn('action', Str::studly("abstract_{$this->fqnHelper()->getModel()}_action"), true);
+    }
+
+    protected function getVariables(): array
+    {
+        $h = $this->fqnHelper();
+
+        $actionFqn = $this->getClassFqn();
+        $repositoryFqn = $h->repositoryInterfaceFqn();
+
+        return [
+            'namespace' => $h->getModelNamespace('action', true),
+            'className' => $h->baseClass($actionFqn),
+            'repositoryInterfaceFqn' => $repositoryFqn,
+            'repositoryInterface' => $h->baseClass($repositoryFqn),
+        ];
+    }
+}

--- a/src/Commands/MakeDomainAbstractEvent.php
+++ b/src/Commands/MakeDomainAbstractEvent.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace ThisIsDevelopment\LaravelBaseDev\Commands;
+
+use Illuminate\Support\Str;
+
+class MakeDomainAbstractEvent extends AbstractDomainGeneratorCommand
+{
+    protected $name = 'make:domain-abstract-event';
+
+    protected $description = 'Create a new domain-event class';
+
+    protected function getClassFqn(): string
+    {
+        return $this->fqnHelper()->fqn('event', Str::studly("abstract_{$this->fqnHelper()->getModel()}_event"), true);
+    }
+
+    protected function getVariables(): array
+    {
+        $h = $this->fqnHelper();
+
+        $eventFqn = $this->getClassFqn();
+
+        return [
+            'namespace' => $h->getModelNamespace('event', true),
+            'className' => $h->baseClass($eventFqn),
+        ];
+    }
+}

--- a/src/Commands/MakeDomainAction.php
+++ b/src/Commands/MakeDomainAction.php
@@ -2,11 +2,88 @@
 
 namespace ThisIsDevelopment\LaravelBaseDev\Commands;
 
+use Illuminate\Support\Str;
+use Symfony\Component\Console\Input\InputArgument;
+
 class MakeDomainAction extends AbstractDomainGeneratorCommand
 {
     protected $name = 'make:domain-action';
 
     protected $description = 'Create a new domain-action class';
 
-    protected $type = 'Action';
+    protected function getStubName(): string
+    {
+        return match ($this->argument('type')) {
+            'create' => 'stubs/domain-create-action.stub',
+            'delete' => 'stubs/domain-delete-action.stub',
+
+                // catch all. This template is problably the most suitable
+                // for _any_ action that will be performed on the model
+            default => 'stubs/domain-update-action.stub',
+        };
+    }
+
+    protected function getClassFqn(): string
+    {
+        return $this->fqnHelper()->actionFqn($this->argument('type'));
+    }
+
+    protected function getVariables(): array
+    {
+        $h = $this->fqnHelper();
+
+        $actionFqn = $h->actionFqn($this->argument('type'));
+
+        $preEventFqn = $h->eventFqn(match ($this->argument('type')) {
+            'create' => 'creating',
+            'delete' => 'deleting',
+            default => 'updating',
+        });
+
+        $postEventFqn = $h->eventFqn(match ($this->argument('type')) {
+            'create' => 'created',
+            'delete' => 'deleted',
+            default => 'updated',
+        });
+
+        $exceptionFqn = $h->exceptionFqn();
+        $modelFqn = $h->modelFqn();
+        $repositoryInterfaceFqn = $h->repositoryInterfaceFqn();
+
+        $context = [
+            'namespace' => $h->getModelNamespace('action', true),
+            'className' => $h->baseClass($actionFqn),
+
+            'preEventFqn' => $preEventFqn,
+            'preEventClass' => $h->baseClass($preEventFqn),
+            'postEventFqn' => $postEventFqn,
+            'postEventClass' => $h->baseClass($postEventFqn),
+
+            'exceptionFqn' => $exceptionFqn,
+            'exceptionClass' => $h->baseClass($exceptionFqn),
+            'modelFqn' => $modelFqn,
+            'modelClass' => $h->baseClass($modelFqn),
+            'repositoryInterfaceFqn' => $repositoryInterfaceFqn,
+            'repositoryInterface' => $h->baseClass($repositoryInterfaceFqn),
+            'repositoryAction' => Str::camel($this->argument('type')),
+        ];
+
+        if ('delete' !== $this->argument('type')) {
+            $dtoFqn = $h->dtoFqn($this->argument('type'));
+            $context += [
+                'dtoFqn' => $dtoFqn,
+                'dtoClass' => $h->baseClass($dtoFqn)
+            ];
+        }
+
+        return $context;
+    }
+
+    protected function getArguments(): array
+    {
+        return [
+            ...parent::getArguments(),
+            ['type', InputArgument::REQUIRED, 'the type of action to generate']
+        ];
+    }
 }

--- a/src/Commands/MakeDomainAction.php
+++ b/src/Commands/MakeDomainAction.php
@@ -48,7 +48,11 @@ class MakeDomainAction extends AbstractDomainGeneratorCommand
 
         $exceptionFqn = $h->exceptionFqn();
         $modelFqn = $h->modelFqn();
-        $repositoryInterfaceFqn = $h->repositoryInterfaceFqn();
+        $parentFqn = $h->fqn(
+            'action',
+            "abstract_{$this->argument('model')}_action",
+            hasMultiplePerModel: true
+        );
 
         $context = [
             'namespace' => $h->getModelNamespace('action', true),
@@ -63,8 +67,8 @@ class MakeDomainAction extends AbstractDomainGeneratorCommand
             'exceptionClass' => $h->baseClass($exceptionFqn),
             'modelFqn' => $modelFqn,
             'modelClass' => $h->baseClass($modelFqn),
-            'repositoryInterfaceFqn' => $repositoryInterfaceFqn,
-            'repositoryInterface' => $h->baseClass($repositoryInterfaceFqn),
+            'parentClass' => $h->baseClass($parentFqn),
+
             'repositoryAction' => Str::camel($this->argument('type')),
         ];
 

--- a/src/Commands/MakeDomainAction.php
+++ b/src/Commands/MakeDomainAction.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace ThisIsDevelopment\LaravelBaseDev\Commands;
+
+class MakeDomainAction extends AbstractDomainGeneratorCommand
+{
+    protected $name = 'make:domain-action';
+
+    protected $description = 'Create a new domain-action class';
+
+    protected $type = 'Action';
+}

--- a/src/Commands/MakeDomainAction.php
+++ b/src/Commands/MakeDomainAction.php
@@ -17,8 +17,8 @@ class MakeDomainAction extends AbstractDomainGeneratorCommand
             'create' => 'stubs/domain-create-action.stub',
             'delete' => 'stubs/domain-delete-action.stub',
 
-                // catch all. This template is problably the most suitable
-                // for _any_ action that will be performed on the model
+            // catch all. This template is problably the most suitable
+            // for _any_ action that will be performed on the model
             default => 'stubs/domain-update-action.stub',
         };
     }
@@ -68,6 +68,7 @@ class MakeDomainAction extends AbstractDomainGeneratorCommand
             'repositoryAction' => Str::camel($this->argument('type')),
         ];
 
+        // When deleting, dto's do not apply
         if ('delete' !== $this->argument('type')) {
             $dtoFqn = $h->dtoFqn($this->argument('type'));
             $context += [

--- a/src/Commands/MakeDomainDto.php
+++ b/src/Commands/MakeDomainDto.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace ThisIsDevelopment\LaravelBaseDev\Commands;
+
+use Symfony\Component\Console\Input\InputArgument;
+
+class MakeDomainDto extends AbstractDomainGeneratorCommand
+{
+    protected $name = 'make:domain-dto';
+
+    protected $description = 'Create a new domain-dto class';
+
+    protected function getClassFqn(): string
+    {
+        return $this->fqnHelper()->dtoFqn($this->argument('type'));
+    }
+
+    protected function getVariables(): array
+    {
+        $h = $this->fqnHelper();
+
+        $modelFqn = $h->dtoFqn($this->argument('type'));
+
+        return [
+            'namespace' => $h->getModelNamespace('dto', true),
+            'className' => $h->baseClass($modelFqn),
+        ];
+    }
+
+    protected function getArguments(): array
+    {
+        return [
+            ...parent::getArguments(),
+            ['type', InputArgument::REQUIRED, 'the type of event to generate']
+        ];
+    }
+}

--- a/src/Commands/MakeDomainEvent.php
+++ b/src/Commands/MakeDomainEvent.php
@@ -2,11 +2,76 @@
 
 namespace ThisIsDevelopment\LaravelBaseDev\Commands;
 
+use Illuminate\Support\Str;
+use Symfony\Component\Console\Input\InputArgument;
+
 class MakeDomainEvent extends AbstractDomainGeneratorCommand
 {
     protected $name = 'make:domain-event';
 
     protected $description = 'Create a new domain-event class';
 
-    protected $type = 'Event';
+    protected function getStubName(): string
+    {
+        return match ($this->argument('type')) {
+            'creating' => 'stubs/domain-creating-event.stub',
+            'created' => 'stubs/domain-created-event.stub',
+            'deleting' => 'stubs/domain-deleting-event.stub',
+            'deleted' => 'stubs/domain-deleted-event.stub',
+
+            // catch all. This template is problably the most suitable
+            // for _any_ update event that will be performed on the model
+            default => 'stubs/domain-update-event.stub',
+        };
+    }
+
+    protected function getClassFqn(): string
+    {
+        return $this->fqnHelper()->eventFqn($this->argument('type'));
+    }
+
+    protected function getVariables(): array
+    {
+        $h = $this->fqnHelper();
+
+        $eventFqn = $h->eventFqn($this->argument('type'));
+        $parentFqn = $h->fqn(
+            'events',
+            Str::studly("abstract_{$h->getModel()}_event"),
+            hasMultiplePerModel: true
+        );
+
+        $modelFqn = $h->modelFqn();
+
+        if(0 === preg_match('/(?:ed|ing)$/i', $this->argument('type'))) {
+            $this->warn(<<<TXT
+                Uncommon event provided (`{$this->argument('type')}` does not end with `ing` or `ed`)
+                which could lead to invalid Dto references. Please verify generated code!
+            TXT);
+        }
+
+        $dtoFqn = $h->dtoFqn(preg_replace(
+            '/(?:ed|ing)$/i', 'e', $this->argument('type')
+        ));
+
+        return [
+            'namespace' => $h->getModelNamespace('event', true),
+            'className' => $h->baseClass($eventFqn),
+            'extends' => $h->baseClass($parentFqn),
+            'modelFqn' => $modelFqn,
+            'modelClass' => $h->baseClass($modelFqn),
+            'modelVar' => $h->asVariable($modelFqn),
+            'dtoFqn' => $dtoFqn,
+            'dtoClass' => $h->baseClass($dtoFqn),
+            'dtoVar' => $h->asVariable($dtoFqn),
+        ];
+    }
+
+    protected function getArguments(): array
+    {
+        return [
+            ...parent::getArguments(),
+            ['type', InputArgument::REQUIRED, 'the type of event to generate']
+        ];
+    }
 }

--- a/src/Commands/MakeDomainEvent.php
+++ b/src/Commands/MakeDomainEvent.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace ThisIsDevelopment\LaravelBaseDev\Commands;
+
+class MakeDomainEvent extends AbstractDomainGeneratorCommand
+{
+    protected $name = 'make:domain-event';
+
+    protected $description = 'Create a new domain-event class';
+
+    protected $type = 'Event';
+}

--- a/src/Commands/MakeDomainEvent.php
+++ b/src/Commands/MakeDomainEvent.php
@@ -43,7 +43,7 @@ class MakeDomainEvent extends AbstractDomainGeneratorCommand
 
         $modelFqn = $h->modelFqn();
 
-        if(0 === preg_match('/(?:ed|ing)$/i', $this->argument('type'))) {
+        if (0 === preg_match('/(?:ed|ing)$/i', $this->argument('type'))) {
             $this->warn(<<<TXT
                 Uncommon event provided (`{$this->argument('type')}` does not end with `ing` or `ed`)
                 which could lead to invalid Dto references. Please verify generated code!
@@ -51,7 +51,9 @@ class MakeDomainEvent extends AbstractDomainGeneratorCommand
         }
 
         $dtoFqn = $h->dtoFqn(preg_replace(
-            '/(?:ed|ing)$/i', 'e', $this->argument('type')
+            '/(?:ed|ing)$/i',
+            'e',
+            $this->argument('type')
         ));
 
         return [

--- a/src/Commands/MakeDomainException.php
+++ b/src/Commands/MakeDomainException.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace ThisIsDevelopment\LaravelBaseDev\Commands;
+
+class MakeDomainException extends AbstractDomainGeneratorCommand
+{
+    protected $name = 'make:domain-exception';
+
+    protected $description = 'Create a new domain-exception class';
+
+    protected $type = 'Exception';
+
+    protected $hasMultiplePerModel = false;
+}

--- a/src/Commands/MakeDomainException.php
+++ b/src/Commands/MakeDomainException.php
@@ -8,7 +8,20 @@ class MakeDomainException extends AbstractDomainGeneratorCommand
 
     protected $description = 'Create a new domain-exception class';
 
-    protected $type = 'Exception';
+    protected function getClassFqn(): string
+    {
+        return $this->fqnHelper()->exceptionFqn();
+    }
 
-    protected $hasMultiplePerModel = false;
+    protected function getVariables(): array
+    {
+        $h = $this->fqnHelper();
+
+        $exceptionFqn = $h->exceptionFqn();
+
+        return [
+            'namespace' => $h->getModelNamespace('exception', false),
+            'className' => $h->baseClass($exceptionFqn),
+        ];
+    }
 }

--- a/src/Commands/MakeDomainModel.php
+++ b/src/Commands/MakeDomainModel.php
@@ -2,50 +2,26 @@
 
 namespace ThisIsDevelopment\LaravelBaseDev\Commands;
 
-use Symfony\Component\Console\Input\InputOption;
-
 class MakeDomainModel extends AbstractDomainGeneratorCommand
 {
     protected $name = 'make:domain-model';
 
     protected $description = 'Create a new domain-model class';
 
-    protected $type = 'Model';
-
-    protected $hasMultiplePerModel = false;
-
-    public function handle()
+    protected function getClassFqn(): string
     {
-        if (parent::handle() === false && !$this->option('force')) {
-            return false;
-        }
-
-        if ($this->option('all')) {
-            $this->createException();
-            $this->createRepositoryInterface();
-            $this->createAction('create');
-            $this->createAction('update');
-            $this->createAction('delete');
-        }
-
-        return null;
+        return $this->fqnHelper()->modelFqn();
     }
 
-    protected function getOptions()
+    protected function getVariables(): array
     {
+        $h = $this->fqnHelper();
+
+        $modelFqn = $h->modelFqn();
+
         return [
-            ['all', 'a', InputOption::VALUE_NONE, 'Generate all related files'],
-            ['force', null, InputOption::VALUE_NONE, 'Create related files even if the model already exists'],
-         ];
-    }
-
-    private function createAction(string $action)
-    {
-        $this->call('make:domain-action', [
-            'domain' => $this->input->getArgument('domain'),
-            'model' => $this->input->getArgument('name'),
-            'name' => $action,
-            '--all' => true,
-        ]);
+            'namespace' => $h->getModelNamespace('model', false),
+            'className' => $h->baseClass($modelFqn),
+        ];
     }
 }

--- a/src/Commands/MakeDomainModel.php
+++ b/src/Commands/MakeDomainModel.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace ThisIsDevelopment\LaravelBaseDev\Commands;
+
+use Symfony\Component\Console\Input\InputOption;
+
+class MakeDomainModel extends AbstractDomainGeneratorCommand
+{
+    protected $name = 'make:domain-model';
+
+    protected $description = 'Create a new domain-model class';
+
+    protected $type = 'Model';
+
+    protected $hasMultiplePerModel = false;
+
+    public function handle()
+    {
+        if (parent::handle() === false && !$this->option('force')) {
+            return false;
+        }
+
+        if ($this->option('all')) {
+            $this->createException();
+            $this->createRepositoryInterface();
+            $this->createAction('create');
+            $this->createAction('update');
+            $this->createAction('delete');
+        }
+
+        return null;
+    }
+
+    protected function getOptions()
+    {
+        return [
+            ['all', 'a', InputOption::VALUE_NONE, 'Generate all related files'],
+            ['force', null, InputOption::VALUE_NONE, 'Create related files even if the model already exists'],
+         ];
+    }
+
+    private function createAction(string $action)
+    {
+        $this->call('make:domain-action', [
+            'domain' => $this->input->getArgument('domain'),
+            'model' => $this->input->getArgument('name'),
+            'name' => $action,
+            '--all' => true,
+        ]);
+    }
+}

--- a/src/Commands/MakeDomainRepositoryInterface.php
+++ b/src/Commands/MakeDomainRepositoryInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace ThisIsDevelopment\LaravelBaseDev\Commands;
+
+class MakeDomainRepositoryInterface extends AbstractDomainGeneratorCommand
+{
+    protected $name = 'make:domain-repository-interface';
+
+    protected $description = 'Create a new domain-repository interface';
+
+    protected $type = 'Repository';
+
+    protected $hasMultiplePerModel = false;
+}

--- a/src/Commands/MakeDomainRepositoryInterface.php
+++ b/src/Commands/MakeDomainRepositoryInterface.php
@@ -8,7 +8,35 @@ class MakeDomainRepositoryInterface extends AbstractDomainGeneratorCommand
 
     protected $description = 'Create a new domain-repository interface';
 
-    protected $type = 'Repository';
+    protected function getClassFqn(): string
+    {
+        return $this->fqnHelper()->repositoryInterfaceFqn();
+    }
 
-    protected $hasMultiplePerModel = false;
+    protected function getVariables(): array
+    {
+        $h = $this->fqnHelper();
+
+        $exceptionFqn = $h->exceptionFqn();
+        $modelFqn = $h->modelFqn();
+        $repositoryInterfaceFqn = $h->repositoryInterfaceFqn();
+        $createDtoFqn = $h->dtoFqn('create');
+        $updateDtoFqn = $h->dtoFqn('update');
+
+        return [
+            'namespace' => $h->getModelNamespace('repository', false),
+            'className' => $h->baseClass($repositoryInterfaceFqn),
+
+            'exceptionFqn' => $exceptionFqn,
+            'exceptionClass' => $h->baseClass($exceptionFqn),
+
+            'modelFqn' => $modelFqn,
+            'modelClass' => $h->baseClass($modelFqn),
+
+            'createDtoFqn' => $createDtoFqn,
+            'createDtoClass' => $h->baseClass($createDtoFqn),
+            'updateDtoFqn' => $updateDtoFqn,
+            'updateDtoClass' => $h->baseClass($updateDtoFqn)
+        ];
+    }
 }

--- a/src/Generators/FqnHelper.php
+++ b/src/Generators/FqnHelper.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ThisIsDevelopment\LaravelBaseDev\Generators;
+
+use Illuminate\Support\Str;
+
+class FqnHelper
+{
+    public function __construct(
+        protected string $rootNamespace,
+        string $domain,
+        string $model
+    ) {
+        $this->domain = Str::studly(trim($domain));
+        $this->model = Str::studly(trim($model));
+    }
+
+    public function getDomain(): string
+    {
+        return $this->domain;
+    }
+
+    public function getModel(): string
+    {
+        return $this->model;
+    }
+
+    public function modelFqn(): string
+    {
+        return $this->fqn(
+            'model',
+            $this->model,
+        );
+    }
+
+    public function exceptionFqn(): string
+    {
+        return $this->fqn(
+            'exception',
+            Str::studly("{$this->model}_exception"),
+        );
+    }
+
+    public function eventFqn(string $event): string
+    {
+        return $this->fqn(
+            'event',
+            Str::studly("{$this->model}_{$event}_Event"),
+            hasMultiplePerModel: true
+        );
+    }
+
+
+    public function actionFqn(string $action): string
+    {
+        return $this->fqn(
+            'action',
+            Str::studly("{$action}_{$this->model}_Action"),
+            hasMultiplePerModel: true
+        );
+    }
+
+    public function dtoFqn(string $prefix = ''): string
+    {
+        return $this->fqn(
+            'dto',
+            Str::studly(ltrim("{$prefix}_{$this->model}_dto", '_')),
+            hasMultiplePerModel: true
+        );
+    }
+
+    public function repositoryInterfaceFqn(): string
+    {
+        return $this->fqn(
+            'repositories',
+            Str::studly("{$this->model}_repository_interface")
+        );
+    }
+
+    public function baseClass(string $fqn): string
+    {
+        return class_basename($fqn);
+    }
+
+    public function asVariable(string $fqn): string
+    {
+        return Str::camel($this->baseClass($fqn));
+    }
+
+
+    public function getModelNamespace(string $type, bool $hasMultiplePerModel = false): string
+    {
+        return implode('\\', array_filter([
+            trim($this->rootNamespace, '\\'),
+            $this->domain,
+            Str::plural(Str::studly($type)),
+            $hasMultiplePerModel ? $this->model : ''
+        ]));
+    }
+
+    public function fqn(string $type, string $className, bool $hasMultiplePerModel = false): string
+    {
+        return implode('\\', array_map(fn ($e) => trim($e, '\\'), array_filter([
+            $this->getModelNamespace($type, $hasMultiplePerModel),
+            Str::studly($className),
+        ])));
+    }
+}

--- a/src/Helpers/FqnHelper.php
+++ b/src/Helpers/FqnHelper.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace ThisIsDevelopment\LaravelBaseDev\Generators;
+namespace ThisIsDevelopment\LaravelBaseDev\Helpers;
 
 use Illuminate\Support\Str;
 

--- a/src/Providers/BaseDevServiceProvider.php
+++ b/src/Providers/BaseDevServiceProvider.php
@@ -3,7 +3,10 @@
 namespace ThisIsDevelopment\LaravelBaseDev\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use ThisIsDevelopment\LaravelBaseDev\Commands\MakeDomain;
+use ThisIsDevelopment\LaravelBaseDev\Commands\MakeDomainAbstractEvent;
 use ThisIsDevelopment\LaravelBaseDev\Commands\MakeDomainAction;
+use ThisIsDevelopment\LaravelBaseDev\Commands\MakeDomainDto;
 use ThisIsDevelopment\LaravelBaseDev\Commands\MakeDomainEvent;
 use ThisIsDevelopment\LaravelBaseDev\Commands\MakeDomainException;
 use ThisIsDevelopment\LaravelBaseDev\Commands\MakeDomainModel;
@@ -16,11 +19,14 @@ class BaseDevServiceProvider extends ServiceProvider
         // Register the command if we are using the application via the CLI
         if ($this->app->runningInConsole()) {
             $this->commands([
+                MakeDomain::class,
+                MakeDomainAbstractEvent::class,
                 MakeDomainAction::class,
+                MakeDomainDto::class,
                 MakeDomainEvent::class,
                 MakeDomainException::class,
                 MakeDomainModel::class,
-                MakeDomainRepositoryInterface::class
+                MakeDomainRepositoryInterface::class,
             ]);
         }
     }

--- a/src/Providers/BaseDevServiceProvider.php
+++ b/src/Providers/BaseDevServiceProvider.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace ThisIsDevelopment\LaravelBaseDev\Providers;
+
+use Illuminate\Support\ServiceProvider;
+use ThisIsDevelopment\LaravelBaseDev\Commands\MakeDomainAction;
+use ThisIsDevelopment\LaravelBaseDev\Commands\MakeDomainEvent;
+use ThisIsDevelopment\LaravelBaseDev\Commands\MakeDomainException;
+use ThisIsDevelopment\LaravelBaseDev\Commands\MakeDomainModel;
+use ThisIsDevelopment\LaravelBaseDev\Commands\MakeDomainRepositoryInterface;
+
+class BaseDevServiceProvider extends ServiceProvider
+{
+    public function boot()
+    {
+        // Register the command if we are using the application via the CLI
+        if ($this->app->runningInConsole()) {
+            $this->commands([
+                MakeDomainAction::class,
+                MakeDomainEvent::class,
+                MakeDomainException::class,
+                MakeDomainModel::class,
+                MakeDomainRepositoryInterface::class
+            ]);
+        }
+    }
+}

--- a/src/Providers/BaseDevServiceProvider.php
+++ b/src/Providers/BaseDevServiceProvider.php
@@ -4,6 +4,7 @@ namespace ThisIsDevelopment\LaravelBaseDev\Providers;
 
 use Illuminate\Support\ServiceProvider;
 use ThisIsDevelopment\LaravelBaseDev\Commands\MakeDomain;
+use ThisIsDevelopment\LaravelBaseDev\Commands\MakeDomainAbstractAction;
 use ThisIsDevelopment\LaravelBaseDev\Commands\MakeDomainAbstractEvent;
 use ThisIsDevelopment\LaravelBaseDev\Commands\MakeDomainAction;
 use ThisIsDevelopment\LaravelBaseDev\Commands\MakeDomainDto;
@@ -20,6 +21,7 @@ class BaseDevServiceProvider extends ServiceProvider
         if ($this->app->runningInConsole()) {
             $this->commands([
                 MakeDomain::class,
+                MakeDomainAbstractAction::class,
                 MakeDomainAbstractEvent::class,
                 MakeDomainAction::class,
                 MakeDomainDto::class,


### PR DESCRIPTION
This MR introduces new commands for developers to use when starting a new Domain.

The main entry point will be the `make:domain` command:
``` shell
$ ./artisan make:domain Foo Bar
``` 
The sample above creates everything required for the `Bar` model in the `Foo` domain. 

Additionally, users have all other (sub-)commands to their disposal as well:
- `make:domain-repository-interface {domain} {model}`
- `make:domain-exception {domain} {model}`
- `make:domain-model {domain} {model}`
- `make:domain-abstract-event {domain} {model}`
- `make:domain-event {domain} {model} {type}`
- `make:domain-action {domain} {model} {type}`
- `make:domain-dto {domain} {model} {type}`

The main `make:domain` command will generate the following structure:
```
app/Domain/{domain}/
  Actions/
    {model}/
      Create{model}Action
      Delete{model}Action
      Update{model}Action
  Dtos/
    {model}/
      Create{model}Dto
      Update{model}Dto
  Events/
    {model}/
      Abstract{model}Event
      {model}CreatingEvent
      {model}CreatedEvent
      {model}UpdatingEvent
      {model}UpdatedEvent
      {model}DeletingEvent
      {model}DeletedEvent
  Exceptions/
    {model}Exception
  Models/
    {model}
  Repositories/
    {model}RepositoryInterface
```