### PR TITLE
fix: Use `docker compose` instead of `docker-compose`

### DIFF
--- a/assets/bin/dev
+++ b/assets/bin/dev
@@ -7,7 +7,7 @@ if [ -n "${COMPOSER_RUNTIME_BIN_DIR:-}" ]; then
 else
     cd $(dirname "$0")/../../
 fi
-COMPOSE="docker-compose"
+COMPOSE="docker compose"
 COMPOSE_SERVICE="app"
 
 if [ ! -f "docker-compose.yml" ]; then


### PR DESCRIPTION
Fixes: vendor/thisisdevelopment/laravel-base-dev/assets/bin/dev: line 26: docker-compose: command not found